### PR TITLE
Add Credits to Web App

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,21 @@
 A web app that will be used to consume the Pinterest API on behalf of users
 to create an alternative, simple UI for viewing Boards & Pins.
 
+## Contributing
+
+1. Clone the project
+2. Branch off of `git checkout netlify && git checkout -b YOUR-BRANCH-NAME`
+3. Commit your work and push it up
+4. Open a pull request for your branch using `netlify` as the **base** branch
+5. Wait for Netlify to deploy a preview (see _Details_ next to Merge button)
+6. Preview changes in preview domain provided by Netlify to confirm changes
+7. Confirm changes for both Mobile and Desktop views
+8. Merge branch
+
 ## Credits
 
-Web Development: Anthony Hernandez
+_Concept and Data Science:_ **[Aubrey Browne](https://github.com/AubreyB13)**
+_Web Development:_ **[Anthony Hernandez](https://github.com/tonytino)**
 
 # Create React App README
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## About
 
-**[Simple Pinterest UI](https://jovial-almeida-64a798.netlify.com/)**
+**[Simple Pinterest UI](https://simple-pinterest-ui.netlify.com/)**
 
 A web app that will be used to consume the Pinterest API on behalf of users
 to create an alternative, simple UI for viewing Boards & Pins.

--- a/README.md
+++ b/README.md
@@ -5,16 +5,54 @@
 A web app that will be used to consume the Pinterest API on behalf of users
 to create an alternative, simple UI for viewing Boards & Pins.
 
+## Developing
+
+You'll need either `npm` or `yarn` to develop for this web app. Note that you
+should not use both! This leads to issues, so it's best to chose one and stick
+with it. While `yarn` has historically been favored over `npm`, the differences
+are effectively non-existent at this point. `yarn` certainly has the nicest
+CLI output (subjective, obviously), but `npm` is what you'll come across the
+most on the internet. The choice is yours. _Only run commands presented below
+for one of the two depending on what you've chosen._
+
+```
+brew install npm
+brew install yarn
+```
+
+If you don't already have homebrew installed, visit
+[Homebrew](https://brew.sh/) to get started.
+
+With either `npm` or `yarn` installed, you can now download the necessary
+packages.
+
+```
+npm install
+yarn install
+```
+
+You should now have all the dependencies you need to start the app.
+
+```
+npm start
+yarn start
+```
+
+The app will start on [localhost:3000](http://localhost:3000/).
+
+Have fun and good luck!
+
 ## Contributing
 
-1. Clone the project
-2. Branch off of `git checkout netlify && git checkout -b YOUR-BRANCH-NAME`
-3. Commit your work and push it up
-4. Open a pull request for your branch using `netlify` as the **base** branch
-5. Wait for Netlify to deploy a preview (see _Details_ next to Merge button)
-6. Preview changes in preview domain provided by Netlify to confirm changes
-7. Confirm changes for both Mobile and Desktop views
-8. Merge branch
+1. Branch off of `git checkout netlify && git checkout -b YOUR-BRANCH-NAME`
+2. Commit your work and push it up
+3. Open a pull request for your branch using `netlify` as the **base** branch
+4. Wait for Netlify to deploy a preview (see _Details_ next to Merge button)
+5. Preview changes in preview domain provided by Netlify to confirm changes
+6. Confirm changes for both Mobile and Desktop views
+7. Merge the branch (this will cause the changes to be deployed to production)
+
+_The deploy to production should take less than 5 minutes._
 
 ## Credits
 

--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,7 @@
       class="contributor"
       href="https://github.com/AubreyB13"
       target="_blank"
+      rel="noopener noreferrer"
     >
       Aubrey Browne
     </a>
@@ -59,6 +60,7 @@
       class="contributor"
       href="https://github.com/tonytino"
       target="_blank"
+      rel="noopener noreferrer"
     >
       Anthony Hernandez
     </a>

--- a/public/index.html
+++ b/public/index.html
@@ -41,4 +41,26 @@
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
   </body>
+
+  <footer>
+    Concept and Data Science by:
+    <a
+      class="contributor"
+      href="https://github.com/AubreyB13"
+      target="_blank"
+    >
+      Aubrey Browne
+    </a>
+
+    <br />
+
+    Web Development by:
+    <a
+      class="contributor"
+      href="https://github.com/tonytino"
+      target="_blank"
+    >
+      Anthony Hernandez
+    </a>
+  </footer>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -54,7 +54,7 @@ class App extends Component {
         <main>
           <p>
             <br />
-            Going to build an app that will be used to acquire access to the
+            Building an app that will be used to acquire access to the
             Pinterest API.
             <br />
             <br />

--- a/src/components/SideDrawer/SideDrawer.css
+++ b/src/components/SideDrawer/SideDrawer.css
@@ -27,7 +27,7 @@
 
 .side-drawer ul {
   /* Consume entire height of side-drawer */
-  height: 100%;
+  /* height: 100%; */
   list-style: none;
   display: flex;
   flex-direction: column;
@@ -64,10 +64,38 @@
   color: #ff8100;
 }
 
+.side-drawer__footer {
+  /*min-height: 70%;*/
+  /*background-color: #EFEFEF;*/
+  height: 100%;
+  text-align: center;
+  font-size: x-small;
+  color: grey;
+  padding-right: 1rem;
+}
+
+.side-drawer__footer__content {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding-bottom: 5px;
+}
+
+.side-drawer__footer .contributor {
+  color: black;
+  padding-left: 5px;
+  padding-top: 5px;
+  font-size: medium;
+}
+
 /*
   Toolbar will only be shown when screen size is >= 768px
   SideDrawer will only be shown when screen size is <= 769px
 */
+@media (max-width: 768px) {
+}
+
 @media (min-width: 769px) {
   .side-drawer {
     display: none;

--- a/src/components/SideDrawer/SideDrawer.css
+++ b/src/components/SideDrawer/SideDrawer.css
@@ -67,7 +67,7 @@
 .side-drawer__footer {
   /*min-height: 70%;*/
   /*background-color: #EFEFEF;*/
-  height: 100%;
+  /* height: 100%; */
   text-align: center;
   font-size: x-small;
   color: grey;

--- a/src/components/SideDrawer/SideDrawer.js
+++ b/src/components/SideDrawer/SideDrawer.js
@@ -29,6 +29,30 @@ const sideDrawer = props => {
           <a href="/">Board Name 4</a>
         </li>
       </ul>
+
+      <div className="side-drawer__footer">
+        <div className="side-drawer__footer__content">
+          Concept and Data Science by:
+          <a
+            className="contributor"
+            href="https://github.com/AubreyB13"
+            target="_blank"
+          >
+            Aubrey Browne
+          </a>
+
+          <br />
+
+          Web Development by:
+          <a
+            className="contributor"
+            href="https://github.com/tonytino"
+            target="_blank"
+          >
+            Anthony Hernandez
+          </a>
+        </div>
+      </div>
     </nav>
   );
 };

--- a/src/components/SideDrawer/SideDrawer.js
+++ b/src/components/SideDrawer/SideDrawer.js
@@ -37,6 +37,7 @@ const sideDrawer = props => {
             className="contributor"
             href="https://github.com/AubreyB13"
             target="_blank"
+            rel="noopener noreferrer"
           >
             Aubrey Browne
           </a>
@@ -48,6 +49,7 @@ const sideDrawer = props => {
             className="contributor"
             href="https://github.com/tonytino"
             target="_blank"
+            rel="noopener noreferrer"
           >
             Anthony Hernandez
           </a>

--- a/src/index.css
+++ b/src/index.css
@@ -19,3 +19,32 @@ body {
   font-family: sans-serif;
   height: 100%;
 }
+
+footer {
+  position: fixed;
+  padding: 0.25rem;
+  background-color: #EFEFEF;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 0.5rem;
+  color: grey;
+  padding-right: 1rem;
+}
+
+footer .contributor {
+  color: black;
+  padding-left: 5px;
+  text-decoration: none;
+}
+
+/*
+  Toolbar will only be shown when screen size is >= 768px
+  SideDrawer will only be shown when screen size is <= 769px
+*/
+@media (max-width: 768px) {
+  footer {
+    display: none
+  }
+}


### PR DESCRIPTION
Add credits to web app, with links to GitHub profiles, along with some updates to the README (sections for credits, developing, and contributing).

For mobile views, the credits are shown at the bottom of the side nav.

For desktop views, the credits are shown in the footer of the page. The position of the footer is fixed such that it will always be in view, even when scrolling through content. Size of footer is small enough that this should not impede the view or consume much of the view height.

To preview the changes, visit: https://deploy-preview-5--simple-pinterest-ui.netlify.com

Also worth noting that I've updated the domain of the production website to be a bit nicer than just a random hash (now temporarily named _simple-pinterest-ui_ until a better name is known).

New URL for website: https://simple-pinterest-ui.netlify.com

## Mobile View
![image](https://user-images.githubusercontent.com/10490190/45335297-8b4f7500-b533-11e8-9906-d9aea146d2e4.png)

## Desktop View
![image](https://user-images.githubusercontent.com/10490190/45335278-74a91e00-b533-11e8-8055-3ea6c85db699.png)
