### PR TITLE
Make the Side Drawer scrollable to prevent content overlap

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -6,7 +6,22 @@ main {
   margin-top: 65px;
 }
 
-main p {
-  text-align: center;
-  font-size: large;
+.pins-container img {
+  display: block;
+  margin: auto;
+  height: auto;
+}
+
+
+@media (max-width: 768px) {
+  .pins-container img {
+    max-width: 80%;
+    min-width: 80%;
+  }
+}
+
+@media (min-width: 769px) {
+  .pins-container img {
+    max-width: 50%;
+  }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -52,18 +52,25 @@ class App extends Component {
         { this.renderBackdrop() }
 
         <main>
-          <p>
+          <div className="pins-container">
+            <img src="https://i.pinimg.com/564x/c3/83/3e/c3833e56c5b984cf70b23e9da9cfb6c1.jpg" />
             <br />
-            Building an app that will be used to acquire access to the
-            Pinterest API.
+            <img src="https://i.pinimg.com/564x/4c/6a/98/4c6a988f193b8b0a7ad488d5995c9642.jpg" />
             <br />
+            <img src="https://i.pinimg.com/564x/95/0b/b0/950bb0e6d71372119d8a7a6aa862c295.jpg" />
             <br />
+            <img src="https://i.pinimg.com/564x/f7/c6/2b/f7c62babfe968438947aa9ae11fd1c9d.jpg" />
             <br />
+            <img src="https://i.pinimg.com/564x/fd/ab/6d/fdab6dee09c491aabcce9f3a6c6e2c88.jpg" />
             <br />
+            <img src="https://i.pinimg.com/564x/d4/8f/c2/d48fc2c152cdcac09a82f9b0d3c4ff91.jpg" />
             <br />
+            <img src="https://i.pinimg.com/564x/2b/02/5c/2b025c4f4c3dffec981c88ff62054939.jpg" />
             <br />
-            Coming soon!
-          </p>
+            <img src="https://i.pinimg.com/564x/81/c5/a9/81c5a9ddf9f28a029fc58c4e90d7de25.jpg" />
+            <br />
+            <img src="https://i.pinimg.com/564x/b6/45/9f/b6459fe42b90004790e73d215a18f6b4.jpg" />
+          </div>
         </main>
       </div>
     );

--- a/src/components/SideDrawer/SideDrawer.css
+++ b/src/components/SideDrawer/SideDrawer.css
@@ -71,35 +71,6 @@
   color: #ff8100;
 }
 
-.side-drawer__footer {
-  /*min-height: 70%;*/
-  /*background-color: #EFEFEF;*/
-  text-align: center;
-  font-size: x-small;
-  color: grey;
-  padding-right: 1rem;
-}
-
-.side-drawer__footer__content {
-  /*position: absolute;*/
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding-bottom: 5px;
-}
-
-.side-drawer__footer__content a {
-  font-size: xx-small;
-  text-decoration: none;
-}
-
-.side-drawer__footer .contributor {
-  color: black;
-  padding-left: 5px;
-  padding-top: 5px;
-  font-size: medium;
-}
-
 /*
   Toolbar will only be shown when screen size is >= 768px
   SideDrawer will only be shown when screen size is <= 769px

--- a/src/components/SideDrawer/SideDrawer.css
+++ b/src/components/SideDrawer/SideDrawer.css
@@ -31,10 +31,10 @@
   /* Consume entire height of side-drawer */
   height: 100%;
   list-style: none;
-  display: flex;
-  flex-direction: column;
+  /*display: flex;*/
+  /*flex-direction: column;*/
   /* Position links at top of side-drawer */
-  justify-content: flex-start;
+  /*justify-content: flex-start;*/
   top: 0;
   padding-top: 2rem;
   padding-left: 0;
@@ -42,9 +42,9 @@
   overflow-y: scroll;
 }
 
-::-webkit-scrollbar {
+/*::-webkit-scrollbar {
     width: 0px;
-}
+}*/
 
 .side-drawer li {
   height: 5rem;
@@ -55,7 +55,7 @@
   background: #F0F0F0;
 }
 
-.side-drawer a {
+.side-drawer li a {
   display: flex;
   height: 100%;
   justify-content: center;
@@ -86,6 +86,11 @@
   left: 0;
   right: 0;
   padding-bottom: 5px;
+}
+
+.side-drawer__footer__content a {
+  font-size: xx-small;
+  text-decoration: none;
 }
 
 .side-drawer__footer .contributor {

--- a/src/components/SideDrawer/SideDrawer.css
+++ b/src/components/SideDrawer/SideDrawer.css
@@ -63,7 +63,7 @@
   text-align: center;
   color: teal;
   text-decoration: none;
-  font-size: 1.5rem;
+  font-size: 1.25rem;
 }
 
 .side-drawer a:hover,
@@ -79,7 +79,4 @@
 }
 
 @media (min-width: 769px) {
-  .side-drawer {
-    display: none;
-  }
 }

--- a/src/components/SideDrawer/SideDrawer.css
+++ b/src/components/SideDrawer/SideDrawer.css
@@ -18,6 +18,8 @@
       - Starts fast, slows towards end (ease-out)
   */
   transition: transform 0.3s ease-out;
+  display: flex;
+  flex-direction: column;
 }
 
 .side-drawer.open {
@@ -27,7 +29,7 @@
 
 .side-drawer ul {
   /* Consume entire height of side-drawer */
-  /* height: 100%; */
+  height: 100%;
   list-style: none;
   display: flex;
   flex-direction: column;
@@ -37,6 +39,11 @@
   padding-top: 2rem;
   padding-left: 0;
   margin-top: 0;
+  overflow-y: scroll;
+}
+
+::-webkit-scrollbar {
+    width: 0px;
 }
 
 .side-drawer li {
@@ -67,7 +74,6 @@
 .side-drawer__footer {
   /*min-height: 70%;*/
   /*background-color: #EFEFEF;*/
-  /* height: 100%; */
   text-align: center;
   font-size: x-small;
   color: grey;
@@ -75,7 +81,7 @@
 }
 
 .side-drawer__footer__content {
-  position: absolute;
+  /*position: absolute;*/
   bottom: 0;
   left: 0;
   right: 0;

--- a/src/components/SideDrawer/SideDrawer.js
+++ b/src/components/SideDrawer/SideDrawer.js
@@ -60,32 +60,6 @@ const sideDrawer = props => {
           <a href="/">Board Name 6</a>
         </li>
       </ul>
-
-      <div className="side-drawer__footer">
-        <div className="side-drawer__footer__content">
-          Concept and Data Science by:
-          <a
-            className="contributor"
-            href="https://github.com/AubreyB13"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Aubrey Browne
-          </a>
-
-          <br />
-
-          Web Development by:
-          <a
-            className="contributor"
-            href="https://github.com/tonytino"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Anthony Hernandez
-          </a>
-        </div>
-      </div>
     </nav>
   );
 };

--- a/src/components/SideDrawer/SideDrawer.js
+++ b/src/components/SideDrawer/SideDrawer.js
@@ -28,6 +28,37 @@ const sideDrawer = props => {
         <li>
           <a href="/">Board Name 4</a>
         </li>
+
+        <li>
+          <a href="/">Board Name 5</a>
+        </li>
+
+        <li>
+          <a href="/">Board Name 6</a>
+        </li>
+        <li>
+          <a href="/">Board Name 1</a>
+        </li>
+
+        <li>
+          <a href="/">Board Name 2</a>
+        </li>
+
+        <li>
+          <a href="/">Board Name 3</a>
+        </li>
+
+        <li>
+          <a href="/">Board Name 4</a>
+        </li>
+
+        <li>
+          <a href="/">Board Name 5</a>
+        </li>
+
+        <li>
+          <a href="/">Board Name 6</a>
+        </li>
       </ul>
 
       <div className="side-drawer__footer">

--- a/src/components/SideDrawer/SideDrawer.js
+++ b/src/components/SideDrawer/SideDrawer.js
@@ -14,50 +14,50 @@ const sideDrawer = props => {
     <nav className={drawerClasses}>
       <ul>
         <li>
-          <a href="/">Board Name 1</a>
+          <a href="/">Another Wedding Board</a>
         </li>
 
         <li>
-          <a href="/">Board Name 2</a>
+          <a href="/">Another Wedding Board</a>
         </li>
 
         <li>
-          <a href="/">Board Name 3</a>
+          <a href="/">Another Wedding Board</a>
         </li>
 
         <li>
-          <a href="/">Board Name 4</a>
+          <a href="/">Another Wedding Board</a>
         </li>
 
         <li>
-          <a href="/">Board Name 5</a>
+          <a href="/">Another Wedding Board</a>
         </li>
 
         <li>
-          <a href="/">Board Name 6</a>
+          <a href="/">Another Wedding Board</a>
         </li>
         <li>
-          <a href="/">Board Name 1</a>
-        </li>
-
-        <li>
-          <a href="/">Board Name 2</a>
+          <a href="/">Another Wedding Board</a>
         </li>
 
         <li>
-          <a href="/">Board Name 3</a>
+          <a href="/">Another Wedding Board</a>
         </li>
 
         <li>
-          <a href="/">Board Name 4</a>
+          <a href="/">Another Wedding Board</a>
         </li>
 
         <li>
-          <a href="/">Board Name 5</a>
+          <a href="/">Another Wedding Board</a>
         </li>
 
         <li>
-          <a href="/">Board Name 6</a>
+          <a href="/">Another Wedding Board</a>
+        </li>
+
+        <li>
+          <a href="/">Another Wedding Board</a>
         </li>
       </ul>
     </nav>

--- a/src/components/Toolbar/Toolbar.css
+++ b/src/components/Toolbar/Toolbar.css
@@ -40,6 +40,7 @@
 .toolbar__navigation-items a {
   color: white;
   text-decoration: none;
+  font-size: small;
 }
 
 .toolbar__logo a:hover,
@@ -58,18 +59,7 @@
   SideDrawer will only be shown when screen size is <= 769px
 */
 @media (max-width: 768px) {
-  .toolbar__navigation-items {
-    display: none;
-  }
-
 }
 
 @media (min-width: 769px) {
-  .toolbar__toggle-button {
-    display: none;
-  }
-
-  .toolbar__logo {
-    margin-left: 0;
-  }
 }

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -16,7 +16,7 @@ const Toolbar = props => (
 
       <div className="toolbar__logo">
         <a href="/">
-          Simple Pinterest UI
+          Perfect Wedding
         </a>
       </div>
 
@@ -25,19 +25,7 @@ const Toolbar = props => (
       <div className="toolbar__navigation-items">
         <ul>
           <li>
-            <a href="/">Board Name 1</a>
-          </li>
-
-          <li>
-            <a href="/">Board Name 2</a>
-          </li>
-
-          <li>
-            <a href="/">Board Name 3</a>
-          </li>
-
-          <li>
-            <a href="/">Board Name 4</a>
+            <a href="/">Log Out</a>
           </li>
         </ul>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -42,9 +42,10 @@ footer .contributor {
 /*
   Toolbar will only be shown when screen size is >= 768px
   SideDrawer will only be shown when screen size is <= 769px
-*/
+*//*
 @media (max-width: 768px) {
   footer {
     display: none
   }
 }
+*/


### PR DESCRIPTION
- Make the Side Drawer content scrollable.
- Remove credits from side and make uniform across web app
- Repurpose Toolbar to not be a nav (just log out button for now)
- Add some content to make the website feel more like a prototype

## Mobile View
![image](https://user-images.githubusercontent.com/10490190/45410171-f1b4c000-b625-11e8-9b8e-d48c89ec602e.png)

## Desktop View
![image](https://user-images.githubusercontent.com/10490190/45410203-05602680-b626-11e8-839d-eb70ac27a3f7.png)
